### PR TITLE
Add CI workflow to run Cucumber tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: test
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run Cucumber tests
+        run: npm test


### PR DESCRIPTION
## Summary
random-server already has a Cucumber test suite (6 feature files) but no CI ran it — tests only executed when run locally. This adds a `test` workflow so every push/PR to `main` runs them.

## Workflow
On push/PR to `main` (Node 24, matching the `node:24-alpine` Dockerfile base):
1. `npm ci`
2. `npm run build` — required because the tests spawn the **compiled** server (`node dist/index.js`) in `BeforeAll`
3. `npm test` — `cucumber-js`

## Verification
Ran the exact recipe locally: build succeeds, then **6 scenarios / 41 steps pass** (server starts on :3100 and shuts down cleanly via SIGTERM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)