### PR TITLE
Enforce optional API key on the /v1 routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,22 @@ docker run -p 1220:3100 -e APP_NAME=my-custom-server --name random-server ghcr.i
 
 The `APP_NAME` will appear in the root endpoint response and 404 error responses. If not set, it defaults to `random-server`.
 
+### Require an API key
+
+The `/v1` routes can require an `x-api-key` header. Enforcement is **off by default** and turns on only when you set the `API_KEY` environment variable at launch:
+
+```sh
+docker run -p 1220:3100 -e API_KEY=your-secret-key --name random-server ghcr.io/mitchallen/random-server:latest
+```
+
+With `API_KEY` set, requests to `/v1/*` must send a matching header or receive `401 unauthorized`:
+
+```sh
+curl -H "x-api-key: your-secret-key" http://localhost:1220/v1/people
+```
+
+The root (`/`) health check and the Swagger explorer (`/api-docs`) remain open regardless. If `API_KEY` is not set, the API is open (no key required).
+
 From the doc:
 
 * https://docs.docker.com/engine/reference/commandline/run/#parent-command

--- a/features/auth.feature
+++ b/features/auth.feature
@@ -1,0 +1,20 @@
+Feature: API key enforcement
+  When the server is launched with an API_KEY set, the /v1 routes require a
+  matching x-api-key header. The test server is started with API_KEY=demo-key.
+
+  Background:
+    Given the server is running
+
+  Scenario: Request with a valid api key succeeds
+    When the "/v1/people/count" endpoint is requested
+    Then the response status should be 200
+
+  Scenario: Request without an api key is rejected
+    When the "/v1/people/count" endpoint is requested without an api key
+    Then the response status should be 401
+    And the response should have error "unauthorized"
+
+  Scenario: Request with an invalid api key is rejected
+    When the "/v1/people/count" endpoint is requested with an invalid api key
+    Then the response status should be 401
+    And the response should have error "unauthorized"

--- a/features/server-steps.js
+++ b/features/server-steps.js
@@ -7,9 +7,15 @@ const TEST_PORT = process.env.TEST_PORT || PORT;
 
 let serverProcess;
 
+const API_KEY = 'demo-key';
+
 BeforeAll(async function () {
-    // Start the server
-    serverProcess = spawn('npm', ['start'], { stdio: 'inherit' });
+    // Start the server with API key enforcement enabled so the auth
+    // scenarios exercise the guard.
+    serverProcess = spawn('npm', ['start'], {
+        stdio: 'inherit',
+        env: { ...process.env, API_KEY },
+    });
 
     // Wait for the server to start (you might need to adjust the delay)
     await new Promise(resolve => setTimeout(resolve, 5000));
@@ -54,8 +60,28 @@ Then('the response should contain a version property', async function () {
 })
 
 When('the {string} endpoint is requested', async function (endpoint) {
-    const res = await fetch(`http://localhost:${TEST_PORT}${endpoint}`);
-    this.response = { data: await res.json() };
+    const res = await fetch(`http://localhost:${TEST_PORT}${endpoint}`, { headers: this.world.headers });
+    this.response = { status: res.status, data: await res.json() };
+});
+
+When('the {string} endpoint is requested without an api key', async function (endpoint) {
+    const res = await fetch(`http://localhost:${TEST_PORT}${endpoint}`, { headers: { accept: 'application/json' } });
+    this.response = { status: res.status, data: await res.json() };
+});
+
+When('the {string} endpoint is requested with an invalid api key', async function (endpoint) {
+    const res = await fetch(`http://localhost:${TEST_PORT}${endpoint}`, {
+        headers: { accept: 'application/json', 'x-api-key': 'wrong-key' },
+    });
+    this.response = { status: res.status, data: await res.json() };
+});
+
+Then('the response status should be {int}', function (status) {
+    assert.strictEqual(this.response.status, status);
+});
+
+Then('the response should have error {string}', function (error) {
+    assert.strictEqual(this.response.data.error, error);
 });
 
 Then('the response should be a JSON array', function () {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import express, { Request, Response } from 'express';
+import express, { Request, Response, NextFunction } from 'express';
 import { Request as ExpressRequest } from 'express';
 import swaggerJsdoc from 'swagger-jsdoc';
 import swaggerUi from 'swagger-ui-express';
@@ -30,6 +30,24 @@ const joinUrlPath = (base: string, ...paths: string[]): string => {
 };
 const PATH = joinUrlPath(BASE_PATH, '/v1');
 const PORT: number = process.env.PORT ? parseInt(process.env.PORT) : 3100;
+
+// Optional API key. When API_KEY is set at launch, the /v1 routes require a
+// matching x-api-key header; when unset, the API is open (no enforcement).
+const API_KEY = process.env.API_KEY;
+const apiKeyGuard = (req: Request, res: Response, next: NextFunction) => {
+    if (!API_KEY) {
+        return next();
+    }
+    if (req.header('x-api-key') === API_KEY) {
+        return next();
+    }
+    return res.status(401).json({
+        status: '401',
+        error: 'unauthorized',
+        app: APP_NAME,
+        version: APP_VERSION,
+    });
+};
 
 // swagger 
 const EXPLORER_PATH = joinUrlPath(BASE_PATH, '/api-docs');
@@ -129,6 +147,9 @@ const randomCoord = randomCoordRouter(randomConfig);
 const randomPersons = randomPersonRouter(randomConfig);
 
 app.use(cors());
+
+// Guard the API routes with the optional API key
+app.use(PATH, apiKeyGuard);
 
 app.use(PATH, emptyRecords);
 app.use(PATH, randomWords);


### PR DESCRIPTION
## Summary
The OpenAPI spec documented an `x-api-key` header as **required**, but nothing actually enforced it — `/v1` routes returned data with or without the header. This adds real enforcement, configured at launch (as the header requirement implies).

## Changes
- **`API_KEY` env var (launch-time).** When set, `/v1/*` requires a matching `x-api-key` header or returns `401 unauthorized`. When unset, the API stays **open** (backward compatible). The root `/` health check and `/api-docs` explorer remain open regardless (the guard is scoped to `/v1`).
- **Tests.** New `features/auth.feature` (valid key → 200, missing → 401, invalid → 401). The test server now launches with `API_KEY=demo-key`, and the existing request step sends the header so the pre-existing data-route scenarios keep passing against the now-enforcing server.
- **README.** Documents the `API_KEY` env var with a `docker run -e API_KEY=...` example.

## Why launch-time
OpenAPI `required: true` is documentation only — the running server never reads the spec. Enforcement needs middleware plus a configured expected value, which is supplied via env at startup.

## Verification
- `npm run build` + `npm test` → **9 scenarios / 52 steps pass** (was 6/41).
- Manual: open mode returns `200` without a header; enforced mode returns `401` (no key / wrong key) and `200` (correct key); root + Swagger stay `200` in enforced mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)