### PR TITLE
Fix Dependabot alerts: brace-expansion, js-yaml, body-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@mitchallen/uptime": "0.0.8",
-        "body-parser": "^1.20.4",
+        "body-parser": "^1.20.6",
         "chance": "^1.1.0",
         "cors": "^2.8.5",
         "express": "^4.22.1",
@@ -624,9 +624,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -663,15 +663,15 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-from": {
@@ -1704,9 +1704,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "dependencies": {
     "@mitchallen/uptime": "0.0.8",
-    "body-parser": "^1.20.4",
+    "body-parser": "^1.20.6",
     "chance": "^1.1.0",
     "cors": "^2.8.5",
     "express": "^4.22.1",
@@ -39,12 +39,12 @@
     "swagger-ui-express": "^5.0.1"
   },
   "overrides": {
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.0",
     "qs": ">=6.15.2",
-    "brace-expansion": ">=5.0.6",
+    "brace-expansion": ">=5.0.7",
     "copyfiles": {
       "minimatch": {
-        "brace-expansion": ">=1.1.13"
+        "brace-expansion": ">=5.0.7"
       }
     }
   },


### PR DESCRIPTION
Resolves the three remaining open Dependabot alerts. Dependency version bumps only — no source changes.

| Package | Severity | Alert | Change | Resolves to |
|---|---|---|---|---|
| `brace-expansion` | high | [#83](https://github.com/mitchallen/random-server/security/dependabot/83), [#88](https://github.com/mitchallen/random-server/security/dependabot/88) | override `>=5.0.6` → `>=5.0.7` | 5.0.8 |
| `js-yaml` | high | [#86](https://github.com/mitchallen/random-server/security/dependabot/86) | override `^4.2.0` → `^4.3.0` | 4.3.0 |
| `body-parser` | low | [#87](https://github.com/mitchallen/random-server/security/dependabot/87) | dep `^1.20.4` → `^1.20.6` | 1.20.6 |

### Notes

- **brace-expansion** — DoS via exponential-time expansion of consecutive non-expanding `{}` groups. The nested `copyfiles.minimatch` override also moves from `>=1.1.13` to `>=5.0.7`: npm was already resolving that path to 5.x via the top-level override, so this makes the intent explicit rather than changing behavior. The build exercises that exact path (`copyfiles` → `minimatch@3.1.5` → `brace-expansion@5.0.8`) and passes.
- **js-yaml** — YAML merge-key chains can force quadratic CPU consumption. 4.3.0 is a patch within the same major.
- All three are transitive/dev-facing; `fast-uri` was already handled by #50.

### Verification

- `npm audit` → **0 vulnerabilities** (was 1 high + 1 low)
- `npm run build` → passes
- `npm test` → **9 scenarios / 52 steps, all passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)