### PR TITLE
Remove the dead body-parser direct dependency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,14 +12,6 @@ Run `gh issue list` for the current state.
 
 - _No open issues._ (#48, the Express 5 upgrade, was completed in PR #54.)
 
-Known cleanup, not yet ticketed:
-
-- **`body-parser` is a dead direct dependency.** Nothing in `src/` or `features/`
-  imports it — the code uses `express.json()`. Since the Express 5 upgrade the
-  tree carries two copies: the vestigial direct `body-parser@1.x` and Express's
-  own bundled `body-parser@2.x`. Safe to drop from `dependencies`; it only
-  generates Dependabot noise for a package the app never loads.
-
 ## Conventions
 
 - **TypeScript build:** source in `src/`, compiled to `dist/` via `npm run build`
@@ -38,6 +30,10 @@ Known cleanup, not yet ticketed:
   form `app.get('/*splat', ...)` (see the 404 catch-all at the end of
   `src/index.ts`, which must stay last). Named `:id` params are unchanged.
   `req.param()`, `res.sendfile()` and `app.del()` are also removed.
+- **Body parsing:** use the built-in `express.json()` (see `src/index.ts`, which
+  wires it with a `verify` hook that rejects malformed JSON with a 400). Don't
+  re-add `body-parser` as a direct dependency — Express 5 bundles its own copy,
+  and a second one is dead weight plus a Dependabot alert surface.
 - **API key:** `/v1` routes require `x-api-key` only when `API_KEY` is set at
   launch; root `/` and `/api-docs` stay open. If `API_KEY` is unset the API is open.
 - Default branch is `main`. Work on a branch and open a PR (CI gates merges).

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@mitchallen/uptime": "0.0.8",
-        "body-parser": "^1.20.6",
         "chance": "^1.1.0",
         "cors": "^2.8.5",
         "express": "^5.2.1",
@@ -643,45 +642,6 @@
         "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/body-parser": {
-      "version": "1.20.6",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
-      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "~1.2.0",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "on-finished": "~2.4.1",
-        "qs": "~6.15.1",
-        "raw-body": "~2.5.3",
-        "type-is": "~1.6.18",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/body-parser/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/body-parser/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
     "node_modules/brace-expansion": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
@@ -1031,16 +991,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/diff": {
@@ -1676,18 +1626,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -1935,15 +1873,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
@@ -1967,27 +1896,6 @@
       },
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -2302,21 +2210,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/raw-body": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
-      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/read-package-up": {
@@ -3064,19 +2957,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "license": "MIT",
-      "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "license": "MIT",
   "dependencies": {
     "@mitchallen/uptime": "0.0.8",
-    "body-parser": "^1.20.6",
     "chance": "^1.1.0",
     "cors": "^2.8.5",
     "express": "^5.2.1",


### PR DESCRIPTION
Follow-up to #54, which flagged this. Nothing in `src/` or `features/` imports `body-parser` — the code uses the built-in `express.json()`.

Since the Express 5 upgrade the tree carried **two** copies: the vestigial direct `body-parser@1.20.6` and Express's own bundled `body-parser@2.3.0`. Only the bundled one was ever loaded.

Removing it drops 120 lines of lockfile, shrinks the production image (it was being installed by `npm ci --omit=dev`), and removes an alert surface for a package the app never required — `body-parser@1.x` was the subject of a Dependabot alert earlier today purely as dead weight.

`CLAUDE.md` drops the now-completed cleanup note and gains a body-parsing convention so it doesn't get reintroduced.

## Verification

| Check | Result |
|---|---|
| `npm run build` | passes |
| `npm test` | 11 scenarios / 60 steps pass |
| `npm audit` | 0 vulnerabilities |
| `npm ls body-parser` | only `express@5.2.1 → body-parser@2.3.0` |

Confirmed in the **built production image**:

- no top-level `body-parser` in `node_modules` ✅
- `express 5.2.1`, bundled `body-parser 2.3.0` ✅
- `/` · `/api-docs/` · `/v1/{people,words,values/count,coords/1,empty}` all 200 ✅
- unknown + nested unknown routes 404 ✅
- API key auth: 401 missing, 401 invalid ✅
- `express.json()` verify hook intact: malformed JSON → `400 {"error":"Invalid JSON"}` ✅

That last check is the one that actually matters here — it's the only body-parsing behavior in the app, and it now runs purely through Express's bundled parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)